### PR TITLE
Fixed Travis build-status image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Unirest for Java [![Build Status][travis-image]][travis-url]
+# Unirest for Java [![Build Status](https://travis-ci.org/Kong/unirest-java.svg?branch=master)](https://travis-ci.org/Kong/unirest-java)
 
 ![][unirest-logo]
 


### PR DESCRIPTION
Either the variables referenced in readme need to be updated (where?) or change to full URL.  Caused be org name change.